### PR TITLE
Allow non-void middleware types

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -22,6 +22,7 @@ describe("isValidMiddleware", () => {
 
   it("returns true for valid input", () => {
     expect(isValidMiddleware((arg1, arg2, arg3) => {})).toBe(true);
+    expect(isValidMiddleware(async (arg1, arg2, arg3) => {})).toBe(true);
   });
 
   it("throws errors for invalid input when throwOnError is enabled", () => {
@@ -115,12 +116,10 @@ describe("label", () => {
       normal: (req, res, next) => next(),
     });
 
-    // @ts-expect-error
     expect(() => middleware("normal", [(a, b) => {}])).toThrowError(
       "Invalid middleware"
     );
 
-    // @ts-expect-error
     expect(() => middleware("normal", (a, b) => {})).toThrowError(
       "Invalid middleware"
     );

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,8 +4,8 @@ export interface Middleware {
   (
     req: NextApiRequest,
     res: NextApiResponse,
-    next: () => Promise<void>
-  ): Promise<void>;
+    next: () => void | Promise<void>
+  ): void | Promise<void>;
 }
 
 export interface LabeledMiddleware {


### PR DESCRIPTION
This PR propose allowing middlewares that aren't returning promises (e.g. https://github.com/expressjs/cors).

Merge is optional. ✌🏻