### PR TITLE
Add passthrough promise responses (fixes #58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ It is worth noting that although these phases are available to all middleware fu
 
 For example, in error catching middleware you might simply wrap `await next()` in a `try / catch` block. On the other hand, you might have request timing middleware that captures a start time during the setup phase, waits, and then captures a finish time in the teardown phase.
 
+You can also optionally abort the chain by returning a resolved value from your middleware rather than calling `await next()`. If a returned value is detected, `next-api-middleware` will not call the next middleware, nor their API Route Handler. This is useful if you want your middleware to handle the response for your API route.
+
 ## APIs
 
 ### `label`

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,8 +3,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 export type Middleware<Request = NextApiRequest, Response = NextApiResponse> = (
   req: Request,
   res: Response,
-  next: () => Promise<void>
-) => Promise<void>;
+  next: () => Promise<any>
+) => Promise<any>;
 
 export type LabeledMiddleware<
   Request = NextApiRequest,

--- a/lib/use.spec.ts
+++ b/lib/use.spec.ts
@@ -4,4 +4,130 @@ describe("use", () => {
   it("throws an error for invalid middleware", () => {
     expect(() => use(() => null)).toThrowError();
   });
+
+  it("resolves with the middleware response if middleware bypasses handler", async () => {
+    const apiHandler = () => {
+      return Promise.resolve('handler response!')
+    }
+
+    const middleware = async (req, res, next) => {
+      await next();
+      return Promise.resolve('middleware response!');
+    }
+
+    const wrappedHandler = use(middleware)(apiHandler)
+
+    const result = await wrappedHandler();
+
+    expect(result).toEqual('middleware response!');
+  });
+
+  it("rejects with the middleware failure if middleware bypasses handler", async () => {
+    const apiHandler = () => {
+      return Promise.resolve('handler response!')
+    }
+
+    const middleware = async (req, res, next) => {
+      await next();
+      return Promise.reject('middleware failure!');
+    }
+
+    const wrappedHandler = use(middleware)(apiHandler)
+
+    try {
+      await wrappedHandler();
+    } catch (err) {
+      expect(err).toEqual('middleware failure!')
+    }
+  });
+
+  it("resolves with the handler response if middleware forwards it", async () => {
+    const apiHandler = () => {
+      return Promise.resolve('handler response!')
+    }
+
+    const middleware = async (req, res, next) => {
+      return await next();
+    }
+
+    const wrappedHandler = use(middleware)(apiHandler)
+
+    const result = await wrappedHandler();
+
+    expect(result).toEqual('handler response!');
+  });
+
+  it("rejects with the handler failure if middleware forwards it", async () => {
+    const apiHandler = () => {
+      return Promise.reject('handler failure!')
+    }
+
+    const middleware = async (req, res, next) => {
+      return await next();
+    }
+
+    const wrappedHandler = use(middleware)(apiHandler)
+
+    try {
+      await wrappedHandler();
+    } catch (err) {
+      expect(err).toEqual('handler failure!')
+    }
+  });
+
+  it("does not proceed to the next middleware if the first one resolves", async () => {
+    const one = jest.fn();
+    const two = jest.fn();
+
+    const apiHandler = () => {
+      return Promise.resolve('handler response!')
+    }
+
+    const middlewareOne = async (req, res, next) => {
+      one();
+      return Promise.resolve('stop here');
+    }
+
+    const middlewareTwo = async (req, res, next) => {
+      two();
+      return await next();
+    }
+
+    const wrappedHandler = use(middlewareOne, middlewareTwo)(apiHandler)
+
+    const result = await wrappedHandler();
+    expect(result).toEqual('stop here');
+    expect(one).toHaveBeenCalled()
+    expect(two).not.toHaveBeenCalled()
+  });
+
+  it("does not proceed to the next middleware if the first one rejects", async () => {
+    const one = jest.fn();
+    const two = jest.fn();
+
+    const apiHandler = () => {
+      return Promise.resolve('handler response!')
+    }
+
+    const middlewareOne = async (req, res, next) => {
+      one();
+      return Promise.reject('stop here');
+    }
+
+    const middlewareTwo = async (req, res, next) => {
+      two();
+      return await next();
+    }
+
+    const wrappedHandler = use(middlewareOne, middlewareTwo)(apiHandler)
+
+    try {
+      await wrappedHandler();
+    } catch (err) {
+      expect(err).toEqual('stop here')
+    }
+
+    expect(one).toHaveBeenCalled()
+    expect(two).not.toHaveBeenCalled()
+  });
 });


### PR DESCRIPTION
Fixes the issue described in:

- #58

This PR ensures that responses and rejections of the API handler, as well as middlewares is passed through all the way the promise chain.

With these changes the library is now much more powerful and gives users the ability to abort the promise chain by returning something from the middleware. For example, I added this test:

```js
it("does not proceed to the next middleware if the first one resolves", async () => {
    const one = jest.fn();
    const two = jest.fn();

    const apiHandler = () => {
      return Promise.resolve('handler response!')
    }

    const middlewareOne = async (req, res, next) => {
      one();
      return Promise.resolve('stop here');
    }

    const middlewareTwo = async (req, res, next) => {
      two();
      return await next();
    }

    const wrappedHandler = use(middlewareOne, middlewareTwo)(apiHandler)

    const result = await wrappedHandler();
    expect(result).toEqual('stop here');
    expect(one).toHaveBeenCalled()
    expect(two).not.toHaveBeenCalled()
  });
```

As a result, I think the middleware API is now a bit more intuitive.

- If you call `next()` it continues to the next middleware,
- If you `return` something, it stops and doesn't call the next middleware nor the api handler

PR includes full test coverage:

```
---------------|---------|----------|---------|---------|-------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------|---------|----------|---------|---------|-------------------
All files      |     100 |      100 |     100 |     100 |
 executor.ts   |     100 |      100 |     100 |     100 |
 label.ts      |     100 |      100 |     100 |     100 |
 promises.ts   |     100 |      100 |     100 |     100 |
 use.spec.ts   |     100 |      100 |     100 |     100 |
 use.ts        |     100 |      100 |     100 |     100 |
 validation.ts |     100 |      100 |     100 |     100 |
---------------|---------|----------|---------|---------|-------------------
Test Suites: 4 passed, 4 total
Tests:       24 passed, 24 total
Snapshots:   0 total
Time:        2.106 s
```